### PR TITLE
Fix soul drawing offset

### DIFF
--- a/objects/obj_battle_soul/Draw_0.gml
+++ b/objects/obj_battle_soul/Draw_0.gml
@@ -1,0 +1,1 @@
+draw_sprite_ext(sprite_index, image_index, round(x), round(y), image_xscale, image_yscale, image_angle, image_blend, image_alpha);

--- a/objects/obj_battle_soul/obj_battle_soul.yy
+++ b/objects/obj_battle_soul/obj_battle_soul.yy
@@ -8,6 +8,7 @@
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":11,"eventType":7,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":2,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":12,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":8,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
   ],
   "managed":true,
   "name":"obj_battle_soul",


### PR DESCRIPTION
Sometimes the soul gets drawn weirdly when the x and y are not whole numbers.

<img width="220" height="230" alt="image" src="https://github.com/user-attachments/assets/832ec6e0-f319-4e02-a174-c88d6091c0cd" />

<img width="631" height="470" alt="image" src="https://github.com/user-attachments/assets/c0ac4df0-140e-43c8-92a9-e9db1f141dec" />

This pr changes the soul to be drawn on whole numbers (`visible` is automatically applied).